### PR TITLE
Expand icon prop

### DIFF
--- a/src/elements/Button/Button.md
+++ b/src/elements/Button/Button.md
@@ -115,6 +115,11 @@ visual aid as to what it does. Note that the icon must be added to the
 FontAwesome library by the application.
 
 ```jsx
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faReadme } from '@fortawesome/free-brands-svg-icons';
+
+library.add(faReadme);
+
 <Button 
   color="tomato" 
   icon="hand-point-up"/>
@@ -123,6 +128,12 @@ FontAwesome library by the application.
   color="tomato" 
   icon="hand-point-up">
   Click me
+</Button>
+<br/><br/>
+<Button
+  color="red"
+  :icon="['fab', 'readme']">
+  Read me
 </Button>
 ```
 

--- a/src/elements/Button/Button.md
+++ b/src/elements/Button/Button.md
@@ -131,7 +131,7 @@ library.add(faReadme);
 </Button>
 <br/><br/>
 <Button
-  color="red"
+  color="tomato"
   :icon="['fab', 'readme']">
   Read me
 </Button>

--- a/src/elements/Button/Button.vue
+++ b/src/elements/Button/Button.vue
@@ -12,7 +12,7 @@
       <slot name="addons">
         <FontAwesomeIcon
           v-if="icon"
-          :icon="['fas', icon]"
+          :icon="icon"
           fixed-width/>
       </slot>
     </div>
@@ -73,7 +73,7 @@
        * _an icon to use as an add-on_
        */
       icon: {
-        type: String
+        type: [String, Array]
       },
       /**
        * _whether to pad the add-on_

--- a/src/elements/InputField/InputField.md
+++ b/src/elements/InputField/InputField.md
@@ -148,7 +148,7 @@ library.add(faGithub);
   placeholder="Both"/>
 <br/><br/>
 <InputField
-  color="red"
+  color="tomato"
   :icon-set="[['fab', 'github']]"
   type="text"
   placeholder="Brand Icon"/>

--- a/src/elements/InputField/InputField.md
+++ b/src/elements/InputField/InputField.md
@@ -124,6 +124,11 @@ A field can also contain two icons, one on the left and right side each. Note
 that the icon must be added to the FontAwesome library by the application.
 
 ```jsx
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
+
+library.add(faGithub);
+
 <InputField
   color="tomato"
   :icon-set="['keyboard', '']"
@@ -141,6 +146,12 @@ that the icon must be added to the FontAwesome library by the application.
   :icon-set="['keyboard', 'keyboard']"
   type="text"
   placeholder="Both"/>
+<br/><br/>
+<InputField
+  color="red"
+  :icon-set="[['fab', 'github']]"
+  type="text"
+  placeholder="Brand Icon"/>
 ```
 
 If you'd like your own something there, you can override the left and the right

--- a/src/elements/InputField/InputField.vue
+++ b/src/elements/InputField/InputField.vue
@@ -18,7 +18,7 @@
       <slot name="leftAddons">
         <FontAwesomeIcon
           v-if="iconSet[0]"
-          :icon="['fas', iconSet[0]]"
+          :icon="iconSet[0]"
           fixed-width/>
       </slot>
     </div>
@@ -31,7 +31,7 @@
       <slot name="rightAddons">
         <FontAwesomeIcon
           v-if="iconSet[1]"
-          :icon="['fas', iconSet[1]]"
+          :icon="iconSet[1]"
           fixed-width/>
       </slot>
     </div>

--- a/src/elements/ProgressBar/ProgressBar.md
+++ b/src/elements/ProgressBar/ProgressBar.md
@@ -107,9 +107,20 @@ A progress bar may include an icon as well as show the percentage value adjacent
 to it.
 
 ```jsx
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faAccessibleIcon } from '@fortawesome/free-brands-svg-icons';
+
+library.add(faAccessibleIcon);
+
 <ProgressBar 
   color="tomato"
   icon="hourglass-half"
+  :value="20"
+  is-percent-visible/>
+<br/><br/>
+<ProgressBar
+  color="red"
+  :icon="['fab', 'accessible-icon']"
   :value="20"
   is-percent-visible/>
 ```

--- a/src/elements/ProgressBar/ProgressBar.md
+++ b/src/elements/ProgressBar/ProgressBar.md
@@ -119,7 +119,7 @@ library.add(faAccessibleIcon);
   is-percent-visible/>
 <br/><br/>
 <ProgressBar
-  color="red"
+  color="tomato"
   :icon="['fab', 'accessible-icon']"
   :value="20"
   is-percent-visible/>

--- a/src/elements/ProgressBar/ProgressBar.vue
+++ b/src/elements/ProgressBar/ProgressBar.vue
@@ -7,7 +7,7 @@
       <slot name="leftAddons">
         <FontAwesomeIcon
           v-if="icon"
-          :icon="['fas', icon]"
+          :icon="icon"
           fixed-width/>
       </slot>
     </div>
@@ -73,7 +73,7 @@
        * _an icon to use as an add-on for the progress bar_
        */
       icon: {
-        type: String
+        type: [String, Array]
       },
       /**
        * _the progress made so far in the task_

--- a/src/elements/Rating/Rating.md
+++ b/src/elements/Rating/Rating.md
@@ -145,9 +145,9 @@ array length is less or more than prop `max`.
 
 ```jsx
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faAccessibleIcon } from '@fortawesome/free-brands-svg-icons';
+import { faTwitter } from '@fortawesome/free-brands-svg-icons';
 
-library.add(faAccessibleIcon);
+library.add(faTwitter);
 
 <Rating
   color="green"
@@ -155,8 +155,8 @@ library.add(faAccessibleIcon);
   :value="3"/>
 <br/><br/>
 <Rating
-  color="blue"
-  :icon-set="[['fab', 'accessible-icon']]"
+  color="green"
+  :icon-set="[['fab', 'twitter']]"
   :value="3"/>
 ```
 

--- a/src/elements/Rating/Rating.md
+++ b/src/elements/Rating/Rating.md
@@ -144,9 +144,19 @@ icon names. This array will be extended or cropped depending on whether the
 array length is less or more than prop `max`.
 
 ```jsx
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faAccessibleIcon } from '@fortawesome/free-brands-svg-icons';
+
+library.add(faAccessibleIcon);
+
 <Rating
   color="green"
   :icon-set="['heart']"
+  :value="3"/>
+<br/><br/>
+<Rating
+  color="blue"
+  :icon-set="[['fab', 'accessible-icon']]"
   :value="3"/>
 ```
 

--- a/src/elements/Rating/Rating.vue
+++ b/src/elements/Rating/Rating.vue
@@ -12,7 +12,7 @@
       :key="index"
       class="icon unit"
       :class="iconClasses(index)"
-      :icon="['fas', computedIcons[index-1]]"
+      :icon="computedIcons[index-1]"
       fixed-width
       @click="changeRating(index)"/>
   </div>

--- a/src/elements/SelectField/SelectField.md
+++ b/src/elements/SelectField/SelectField.md
@@ -154,6 +154,11 @@ is about. Note that the icon must be added to the FontAwesome library by the
 application.
 
 ```jsx
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faGitAlt } from '@fortawesome/free-brands-svg-icons';
+
+library.add(faGitAlt);
+
 let optionList = [
   {
     value: 'a',
@@ -168,6 +173,11 @@ let optionList = [
 <SelectField
   color="tomato"
   icon="vote-yea"
+  :option-list="optionList"/>
+<br/><br/>
+<SelectField
+  color="red"
+  :icon="['fab', 'git-alt']"
   :option-list="optionList"/>
 ```
 

--- a/src/elements/SelectField/SelectField.md
+++ b/src/elements/SelectField/SelectField.md
@@ -176,7 +176,7 @@ let optionList = [
   :option-list="optionList"/>
 <br/><br/>
 <SelectField
-  color="red"
+  color="tomato"
   :icon="['fab', 'git-alt']"
   :option-list="optionList"/>
 ```

--- a/src/elements/SelectField/SelectField.vue
+++ b/src/elements/SelectField/SelectField.vue
@@ -28,7 +28,7 @@
       <slot name="addons">
         <FontAwesomeIcon
           v-if="icon"
-          :icon="['fas', icon]"
+          :icon="icon"
           fixed-width/>
       </slot>
     </div>
@@ -111,7 +111,7 @@
        * _an icon to use in the dropdown_
        */
       icon: {
-        type: String
+        type: [String, Array]
       },
       /**
        * _the list of options to choose from_

--- a/src/elements/Statistic/Statistic.md
+++ b/src/elements/Statistic/Statistic.md
@@ -169,7 +169,7 @@ library.add(faFontAwesomeFlag);
   </GridCell>
   <GridCell :span-set="[12, 12, 6, 3, 3]">
     <Statistic
-      color="red"
+      color="tomato"
       :icon-set="['', ['fab', 'font-awesome-flag']]"
       label="Icon"
       value="Any"

--- a/src/elements/Statistic/Statistic.md
+++ b/src/elements/Statistic/Statistic.md
@@ -137,8 +137,13 @@ A statistic can be contain two icons, one for the value and the label each. Note
 that the icon must be added to the FontAwesome library by the application.
 
 ```jsx
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faFontAwesomeFlag } from '@fortawesome/free-brands-svg-icons';
+
+library.add(faFontAwesomeFlag);
+
 <Grid style="text-align: center;">
-  <GridCell :span-set="[12, 4, 4, 4, 4]">
+  <GridCell :span-set="[12, 12, 6, 3, 3]">
     <Statistic
       color="tomato"
       :icon-set="['chart-line', '']"
@@ -146,7 +151,7 @@ that the icon must be added to the FontAwesome library by the application.
       value="Value"
       is-textual-value/>
   </GridCell>
-  <GridCell :span-set="[12, 4, 4, 4, 4]">
+  <GridCell :span-set="[12, 12, 6, 3, 3]">
     <Statistic
       color="tomato"
       :icon-set="['', 'chart-line']"
@@ -154,12 +159,20 @@ that the icon must be added to the FontAwesome library by the application.
       value="Label"
       is-textual-value/>
   </GridCell>
-  <GridCell :span-set="[12, 4, 4, 4, 4]">
+  <GridCell :span-set="[12, 12, 6, 3, 3]">
     <Statistic
       color="tomato"
       :icon-set="['chart-line', 'chart-line']"
       label="Icon"
       value="Both"
+      is-textual-value/>
+  </GridCell>
+  <GridCell :span-set="[12, 12, 6, 3, 3]">
+    <Statistic
+      color="red"
+      :icon-set="['', ['fab', 'font-awesome-flag']]"
+      label="Icon"
+      value="Any"
       is-textual-value/>
   </GridCell>
 </Grid>

--- a/src/elements/Statistic/Statistic.vue
+++ b/src/elements/Statistic/Statistic.vue
@@ -6,7 +6,7 @@
         <slot name="valueAddons">
           <FontAwesomeIcon
             v-if="iconSet[0]"
-            :icon="['fas', iconSet[0]]"
+            :icon="iconSet[0]"
             fixed-width/>
         </slot>
       </span>
@@ -21,7 +21,7 @@
         <slot name="labelAddons">
           <FontAwesomeIcon
             v-if="iconSet[1]"
-            :icon="['fas', iconSet[1]]"
+            :icon="iconSet[1]"
             fixed-width/>
         </slot>
       </span>

--- a/src/elements/SwitchField/SwitchField.md
+++ b/src/elements/SwitchField/SwitchField.md
@@ -184,19 +184,27 @@ yourself.
 
 ```jsx
 <Grid>
-  <GridCell :span-set="[12, 6, 6, 6, 6]">
+  <GridCell :span-set="[12, 4, 4, 4, 4]">
     <SwitchField
-      color="tomato" 
+      color="tomato"
       size="huge" 
       :value="true"
       is-labelled/>
   </GridCell>
-  <GridCell :span-set="[12, 6, 6, 6, 6]">
+  <GridCell :span-set="[12, 4, 4, 4, 4]">
     <SwitchField
-      color="tomato" 
+      color="tomato"
       size="huge"
       :value="true"
       :iconSet="['times', 'check']"
+      is-labelled/>
+  </GridCell>
+  <GridCell :span-set="[12, 4, 4, 4, 4]">
+    <SwitchField
+      color="tomato"
+      size="huge"
+      :value="true"
+      :iconSet="[['fab', 'bluetooth-b'], ['fab', 'bluetooth-b']]"
       is-labelled/>
   </GridCell>
 </Grid>

--- a/src/elements/SwitchField/SwitchField.vue
+++ b/src/elements/SwitchField/SwitchField.vue
@@ -8,7 +8,7 @@
       class="symbol off">
       <FontAwesomeIcon
         v-if="iconSet[0]"
-        :icon="['fas', iconSet[0]]"
+        :icon="iconSet[0]"
         fixed-width/>
       <div
         v-else
@@ -22,7 +22,7 @@
       class="symbol on">
       <FontAwesomeIcon
         v-if="iconSet[1]"
-        :icon="['fas', iconSet[1]]"
+        :icon="iconSet[1]"
         fixed-width/>
       <div
         v-else

--- a/src/patterns/Navigation/Navigation.vue
+++ b/src/patterns/Navigation/Navigation.vue
@@ -12,7 +12,7 @@
             tag="span">
             <FontAwesomeIcon
               v-if="navigationLink.icon"
-              :icon="['fas', navigationLink.icon]"
+              :icon="navigationLink.icon"
               fixed-width/>
           </SlotRenderer>
           <SlotRenderer

--- a/src/patterns/Navigation/NavigationLink.md
+++ b/src/patterns/Navigation/NavigationLink.md
@@ -6,18 +6,16 @@ A navigation link can have an icon attached to it via the `icon` prop.
 
 ```jsx
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { 
-  faHome,
-  faBook
-} from '@fortawesome/free-solid-svg-icons';
+import { faHome } from '@fortawesome/free-solid-svg-icons';
+import { faReadme } from '@fortawesome/free-brands-svg-icons';
 
-library.add(faHome, faBook);
+library.add(faHome, faReadme);
 
 <Navigation color="tomato">
   <NavigationLink icon="home">
     Home page
   </NavigationLink>
-  <NavigationLink icon="book">
+  <NavigationLink :icon="['fab', 'readme']">
     Style guide
   </NavigationLink>
 </Navigation>

--- a/src/patterns/Navigation/NavigationLink.vue
+++ b/src/patterns/Navigation/NavigationLink.vue
@@ -26,7 +26,7 @@
        * _the icon to show in the navigation link_
        */
       icon: {
-        type: String
+        type: [String, Array]
       },
       /**
        * _the link that this link should point to_

--- a/src/patterns/Trail/Trail.vue
+++ b/src/patterns/Trail/Trail.vue
@@ -18,7 +18,7 @@
             tag="span">
             <FontAwesomeIcon
               v-if="trailCrumb.icon"
-              :icon="['fas', trailCrumb.icon]"
+              :icon="trailCrumb.icon"
               fixed-width/>
           </SlotRenderer>
           <SlotRenderer
@@ -27,7 +27,7 @@
         </a>
         <FontAwesomeIcon
           class="separator"
-          :icon="['fas', icon]"
+          :icon="icon"
           fixed-width/>
       </li>
     </ul>
@@ -79,7 +79,7 @@
        * _the icon to use as the separator between crumbs_
        */
       icon: {
-        type: String,
+        type: [String, Array],
         default: 'angle-right'
       }
     },

--- a/src/patterns/Trail/TrailCrumb.md
+++ b/src/patterns/Trail/TrailCrumb.md
@@ -10,19 +10,20 @@ A trail crumb can have an icon attached to it via the `icon` prop.
 ```jsx
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { 
+  faAngleDoubleRight,
   faHome,
-  faBook,
   faCubes,
   faCube
 } from '@fortawesome/free-solid-svg-icons';
+import { faReadme } from '@fortawesome/free-brands-svg-icons';
 
-library.add(faHome, faBook, faCubes, faCube);
+library.add(faAngleDoubleRight, faHome, faReadme, faCubes, faCube);
 
-<Trail color="tomato">
+<Trail color="tomato" :icon="['fas', 'angle-double-right']">
   <TrailCrumb icon="home">
     CC Vocabulary
   </TrailCrumb>
-  <TrailCrumb icon="book">
+  <TrailCrumb :icon="['fab', 'readme']">
     Styleguide
   </TrailCrumb>
   <TrailCrumb icon="cubes">

--- a/src/patterns/Trail/TrailCrumb.vue
+++ b/src/patterns/Trail/TrailCrumb.vue
@@ -27,7 +27,7 @@
        * _the icon to show in the trail crumb_
        */
       icon: {
-        type: String
+        type: [String, Array]
       },
       /**
        * _the link that this crumb should point to_


### PR DESCRIPTION
**Fixes**
Fixes #2

**Description**
<!-- A clear and concise description of what the pull request does. -->
Expose the `icon` prop of the `FontAwesomeIcon` component, through the various `icon`, and `iconSet` props.

**Type of PR** 
This PR is a feature.

**Tests**
<!-- Steps for the reviewer to verify that this PR fixes the problem. -->
- Provide string arrays (e.g: `['fas', 'hand-point-up']`) to the components exposing an `icon` prop
- Provide arrays of string arrays (e.g: `[['fas', 'hand-point-up'], ['fas', 'hand-point-down']]`) to the components exposing an `iconSet` prop.

You can also view the changes on the Button, InputField, ProgressBar, Rating, SelectField, Statistic, SwitchField, NavigationLink, and TrailCrumb pages of the Styleguide.

**Checklist:**
<!-- Replace  the [ ] with [x] to check the boxes --> 
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
