### PR TITLE
Add popover for Licenselconography Icons

### DIFF
--- a/src/elements/LicenseIconography/LicenseIconography.md
+++ b/src/elements/LicenseIconography/LicenseIconography.md
@@ -49,3 +49,34 @@ Finally there are icons for the CC Zero license and the Public Domain mark.
 ```jsx { "props": { "className": "enlarged-text" } }
 <LicenseIconography :icon-list="['zero', 'pd']"/>
 ```
+
+### Add-on set
+
+License icons can contain popups with additional content.
+
+```jsx
+<div style="padding: 100px 200px;">
+  <LicenseIconography
+    :icon-list="['', 'zero']"
+    :string-list="['Creative Commons', 'Zero']"/>
+</div>
+```
+
+But if plain strings are not cutting it for you, feel free to populate slots,
+named after icon indices.
+
+```jsx
+<div style="padding: 100px 200px;">
+  <LicenseIconography
+    :icon-list="['', 'zero']">
+    <template #0>
+      <Heading :level="5">Creative Commons</Heading>
+      <Paragraph>When we share, everyone wins.</Paragraph>
+    </template>
+    <template #1>
+      <Heading :level="5">Zero</Heading>
+      <Paragraph>No rights reserved.</Paragraph>
+    </template>
+  </LicenseIconography>
+</div>
+```

--- a/src/elements/LicenseIconography/LicenseIconography.stories.js
+++ b/src/elements/LicenseIconography/LicenseIconography.stories.js
@@ -1,5 +1,7 @@
 import LicenseIconography from '@/elements/LicenseIconography/LicenseIconography'
 
+import { array, optionsKnob as options } from '@storybook/addon-knobs'
+
 export default {
   title: 'Elements|LicenseIconography',
   decorators: [
@@ -41,3 +43,39 @@ export const publicWorks = () => ({
     <LicenseIconography :icon-list="['zero', 'pd']"/>
   `
 })
+
+export const popupable = () => ({
+  components: { LicenseIconography },
+  props: {
+    stringList: {
+      default: () => array('String list', ['Creative Commons'])
+    },
+    iconList: {
+      default: () => options('Icon list', {
+        CC: '',
+        BY: 'by',
+        NC: 'nc',
+        ND: 'nd',
+        SA: 'sa',
+        'NC-EU': 'nc-eu',
+        'NC-JP': 'nc-jp',
+        Sampling: 'sampling',
+        'Sampling Plus': 'sampling-plus',
+        Remix: 'remix',
+        Share: 'share',
+        Zero: 'zero',
+        PD: 'pd'
+      }, [''], {
+        display: 'multi-select'
+      })
+    }
+  },
+  template: `
+    <LicenseIconography :icon-list="iconList" :string-list="stringList"/>
+  `
+})
+popupable.story = {
+  decorators: [
+    () => ({ template: `<div style="font-size: 1rem; padding: 5em 10em;"><story/></div>` })
+  ]
+}

--- a/src/elements/LicenseIconography/LicenseIconography.vue
+++ b/src/elements/LicenseIconography/LicenseIconography.vue
@@ -1,22 +1,25 @@
 <template>
   <span class="vocab license-icons">
-    <Popup v-bind="$attrs"
-    v-if="showsPopup">
-      <FontAwesomeIcon v-for="(icon, index) in processedIconList"
-      :key="index"
-      :icon="['fab', icon]"
-      fixed-width />
-      <template #popup>
-        <Paragraph>
-          <slot>{{ popupContent }}</slot>
-        </Paragraph>
+    <template v-for="(icon, index) in processedIconList">
+      <template v-if="showsPopup(index)">
+        <Popup
+          :key="index"
+          v-bind="$attrs">
+          <FontAwesomeIcon
+            :icon="['fab', icon]"
+            fixed-width/>
+          <template #popup>
+            <!-- @slot Popup content goes here -->
+            <slot :name="index">{{ computedStrings[index] }}</slot>
+          </template>
+        </Popup>
       </template>
-    </Popup>
-    <template v-else>
-      <FontAwesomeIcon v-for="(icon, index) in processedIconList"
-      :key="index"
-      :icon="['fab', icon]"
-      fixed-width />
+      <template v-else>
+        <FontAwesomeIcon
+          :key="index"
+          :icon="['fab', icon]"
+          fixed-width/>
+      </template>
     </template>
   </span>
 </template>
@@ -72,14 +75,6 @@
     },
     inheritAttrs: false,
     props: {
-      showsPopup: {
-        type: Boolean,
-        default: false
-      },
-      popupContent: {
-        type: String,
-        default: 'Creative Commons'
-      },
       /**
        * _the list of icons to display_
        *
@@ -107,6 +102,16 @@
             'pd'
           ].includes(icon)
         )
+      },
+      /**
+       * _the list of strings to show in the popups corresponding to the icons_
+       *
+       * If the length is not equal to the length of `iconList`, the list will
+       * be extended or cropped as needed.
+       */
+      stringList: {
+        type: Array,
+        default: () => []
       }
     },
     computed: {
@@ -114,6 +119,24 @@
         return this.iconList.map(icon => {
           return `creative-commons${icon ? '-' : ''}${icon}`
         })
+      },
+      computedStrings: function () {
+        let arrayLength = this.stringList.length
+        let max = this.iconList.length
+        let stringList = this.stringList.map(string => string.trim())
+        if (arrayLength < max) {
+          let addendumLength = max - arrayLength
+          return stringList.concat(
+            Array(addendumLength).fill(this.stringList[arrayLength - 1])
+          )
+        } else {
+          return stringList.slice(0, max)
+        }
+      }
+    },
+    methods: {
+      showsPopup: function (index) {
+        return this.computedStrings[index] || this.$slots[index]
       }
     }
   }

--- a/src/elements/LicenseIconography/LicenseIconography.vue
+++ b/src/elements/LicenseIconography/LicenseIconography.vue
@@ -1,10 +1,23 @@
 <template>
   <span class="vocab license-icons">
-    <FontAwesomeIcon
-      v-for="(icon, index) in processedIconList"
+    <Popup v-bind="$attrs"
+    v-if="showsPopup">
+      <FontAwesomeIcon v-for="(icon, index) in processedIconList"
       :key="index"
       :icon="['fab', icon]"
-      fixed-width/>
+      fixed-width />
+      <template #popup>
+        <Paragraph>
+          <slot>{{ popupContent }}</slot>
+        </Paragraph>
+      </template>
+    </Popup>
+    <template v-else>
+      <FontAwesomeIcon v-for="(icon, index) in processedIconList"
+      :key="index"
+      :icon="['fab', icon]"
+      fixed-width />
+    </template>
   </span>
 </template>
 
@@ -26,6 +39,8 @@
     faCreativeCommonsShare
   } from '@fortawesome/free-brands-svg-icons'
   import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+  import Popup from '@/patterns/Popup/Popup'
 
   library.add(
     faCreativeCommons,
@@ -52,9 +67,19 @@
   export default {
     name: 'LicenseIconography',
     components: {
-      FontAwesomeIcon
+      FontAwesomeIcon,
+      Popup
     },
+    inheritAttrs: false,
     props: {
+      showsPopup: {
+        type: Boolean,
+        default: false
+      },
+      popupContent: {
+        type: String,
+        default: 'Creative Commons'
+      },
       /**
        * _the list of icons to display_
        *


### PR DESCRIPTION
**Fixes**
<!-- If PR only partly solves the issue, replace 'Fixes' below with 'Partially addresses' -->
Fixes #21 

**Description**
<!-- A clear and concise description of what the pull request does. -->
This adds popup to the Licenselconography Icons. The user can enable popup using a boolean `showPopup` and the popup can be customized using the guidelines laid [here](https://cc-vue-vocabulary.netlify.com/styleguide/#/Patterns/Popup).

The changes are made in the <template/> of the Licenselconography.vue file. A boolean prop `showPopup` has been introduced which decides which template is rendered. $attrs is used to propagate all the attributes to the nested component.

**Type of PR** 
This PR is a **Feature**.

<!-- **Technicalities**
Notable technical details about the implementation. -->

<!--
**Tests**
 Steps for the reviewer to verify that this PR fixes the problem. -->

**Screenshots**
<!-- If applicable, add screenshots to show the problem and the solution. -->
![Screenshot from 2020-01-02 13-13-01](https://user-images.githubusercontent.com/34674462/71656645-0872af00-2d62-11ea-9012-5a71c121b726.png)


**Checklist:**
<!-- Replace  the [ ] with [x] to check the boxes --> 
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
